### PR TITLE
Introduce extra_input_cmd to be able to specify input-side parameters

### DIFF
--- a/haffmpeg/camera.py
+++ b/haffmpeg/camera.py
@@ -8,7 +8,7 @@ class CameraMjpeg(HAFFmpeg):
     """Implement a camera they convert video stream to MJPEG."""
 
     def open_camera(
-        self, input_source: str, extra_cmd: Optional[str] = None
+        self, input_source: str, extra_cmd: Optional[str] = None, extra_input_cmd: Optional[str] = None
     ) -> Coroutine:
         """Open FFmpeg process as mjpeg video stream.
 
@@ -21,4 +21,5 @@ class CameraMjpeg(HAFFmpeg):
             input_source=input_source,
             output="-f mpjpeg -",
             extra_cmd=extra_cmd,
+            extra_input_cmd=extra_input_cmd
         )

--- a/haffmpeg/core.py
+++ b/haffmpeg/core.py
@@ -44,16 +44,21 @@ class HAFFmpeg:
         input_source: Optional[str],
         output: Optional[str],
         extra_cmd: Optional[str] = None,
+        extra_input_cmd: Optional[str] = None
     ) -> None:
         """Generate ffmpeg command line."""
         self._argv = [self._ffmpeg]
+
+        # exists an extra cmd from customer
+        if extra_input_cmd is not None:
+            self._argv.extend(shlex.split(extra_input_cmd))
 
         # start command init
         if input_source is not None:
             self._put_input(input_source)
         self._argv.extend(cmd)
 
-        # exists a extra cmd from customer
+        # exists an extra cmd from customer
         if extra_cmd is not None:
             self._argv.extend(shlex.split(extra_cmd))
 
@@ -108,8 +113,9 @@ class HAFFmpeg:
         input_source: Optional[str],
         output: Optional[str] = "-",
         extra_cmd: Optional[str] = None,
+        extra_input_cmd=None,
         stdout_pipe: bool = True,
-        stderr_pipe: bool = False,
+        stderr_pipe: bool = False
     ) -> bool:
         """Start a ffmpeg instance and pipe output."""
         stdout = subprocess.PIPE if stdout_pipe else subprocess.DEVNULL
@@ -120,7 +126,13 @@ class HAFFmpeg:
             return True
 
         # set command line
-        self._generate_ffmpeg_cmd(cmd, input_source, output, extra_cmd)
+        self._generate_ffmpeg_cmd(
+            cmd=cmd,
+            input_source=input_source,
+            output=output,
+            extra_cmd=extra_cmd,
+            extra_input_cmd=extra_input_cmd,
+        )
 
         # start ffmpeg
         _LOGGER.debug("Start FFmpeg with %s", str(self._argv))
@@ -248,6 +260,7 @@ class HAFFmpegWorker(HAFFmpeg):
         input_source: str,
         output: Optional[str] = None,
         extra_cmd: Optional[str] = None,
+        extra_input_cmd=None,
         pattern: Optional[str] = None,
         reading: str = FFMPEG_STDERR,
     ) -> None:
@@ -269,6 +282,7 @@ class HAFFmpegWorker(HAFFmpeg):
             input_source=input_source,
             output=output,
             extra_cmd=extra_cmd,
+            extra_input_cmd=extra_input_cmd,
             stdout_pipe=stdout,
             stderr_pipe=stderr,
         )

--- a/haffmpeg/sensor.py
+++ b/haffmpeg/sensor.py
@@ -42,6 +42,7 @@ class SensorNoise(HAFFmpegWorker):
         input_source: str,
         output_dest: Optional[str] = None,
         extra_cmd: Optional[str] = None,
+        extra_input_cmd: Optional[str] = None,
     ) -> Coroutine:
         """Open FFmpeg process for read autio stream.
 
@@ -55,6 +56,7 @@ class SensorNoise(HAFFmpegWorker):
             input_source=input_source,
             output=output_dest,
             extra_cmd=extra_cmd,
+            extra_input_cmd=extra_input_cmd,
             pattern="silence",
         )
 
@@ -150,7 +152,7 @@ class SensorMotion(HAFFmpegWorker):
         self._changes = changes
 
     async def open_sensor(
-        self, input_source: str, extra_cmd: Optional[str] = None
+        self, input_source: str, extra_cmd: Optional[str] = None, extra_input_cmd: Optional[str] = None
     ) -> Coroutine:
         """Open FFmpeg process a video stream for motion detection.
 
@@ -168,6 +170,7 @@ class SensorMotion(HAFFmpegWorker):
             input_source=input_source,
             output="-f framemd5 -",
             extra_cmd=extra_cmd,
+            extra_input_cmd=extra_input_cmd,
             pattern=self.MATCH,
             reading=FFMPEG_STDOUT,
         )

--- a/haffmpeg/tools.py
+++ b/haffmpeg/tools.py
@@ -21,6 +21,7 @@ class ImageFrame(HAFFmpeg):
         input_source: str,
         output_format: str = IMAGE_JPEG,
         extra_cmd: Optional[str] = None,
+        extra_input_cmd: Optional[str] = None,
         timeout: int = 15,
     ) -> Optional[bytes]:
         """Open FFmpeg process as capture 1 frame."""
@@ -32,6 +33,7 @@ class ImageFrame(HAFFmpeg):
             input_source=input_source,
             output="-f image2pipe -",
             extra_cmd=extra_cmd,
+            extra_input_cmd=extra_input_cmd,
         )
 
         # error after open?

--- a/test/camera_mjpeg.py
+++ b/test/camera_mjpeg.py
@@ -13,13 +13,14 @@ logging.basicConfig(level=logging.DEBUG)
 @click.option("--source", "-s", help="Input file for ffmpeg")
 @click.option("--output", "-o", help="Output image path")
 @click.option("--extra", "-e", help="Extra ffmpeg command line arguments")
-def cli(ffmpeg, source, output, extra):
+@click.option("--extra-input", "-E", help="Extra ffmpeg command line arguments for input")
+def cli(ffmpeg, source, output, extra, extra_input):
     """FFMPEG capture frame as image."""
 
     async def read_stream():
         """Read stream inside loop."""
         stream = CameraMjpeg(ffmpeg_bin=ffmpeg)
-        await stream.open_camera(source, extra)
+        await stream.open_camera(input_source=source, extra_cmd=extra, extra_input_cmd=extra_input)
 
         reader = await stream.get_reader()
         try:

--- a/test/sensor_motion.py
+++ b/test/sensor_motion.py
@@ -40,7 +40,8 @@ logging.basicConfig(level=logging.DEBUG)
     help="Scene change settings or percent of image they need change",
 )
 @click.option("--extra", "-e", help="Extra ffmpeg command line arguments")
-def cli(ffmpeg, source, reset, repeat_time, repeat, changes, extra):
+@click.option("--extra-input", "-E", help="Extra ffmpeg command line arguments for input")
+def cli(ffmpeg, source, reset, repeat_time, repeat, changes, extra, extra_input):
     """FFMPEG noise detection."""
 
     def callback(state):
@@ -52,7 +53,7 @@ def cli(ffmpeg, source, reset, repeat_time, repeat, changes, extra):
         sensor.set_options(
             time_reset=reset, changes=changes, repeat=repeat, time_repeat=repeat_time
         )
-        await sensor.open_sensor(input_source=source, extra_cmd=extra)
+        await sensor.open_sensor(input_source=source, extra_cmd=extra, extra_input_cmd=extra_input)
         try:
             while True:
                 await asyncio.sleep(0.1)

--- a/test/sensor_noise.py
+++ b/test/sensor_noise.py
@@ -30,7 +30,8 @@ logging.basicConfig(level=logging.DEBUG)
     "--peak", "-p", default=-30, type=int, help="dB for detect a peak. Default -30"
 )
 @click.option("--extra", "-e", help="Extra ffmpeg command line arguments")
-def cli(ffmpeg, source, output, duration, reset, peak, extra):
+@click.option("--extra-input", "-E", help="Extra ffmpeg command line arguments for input")
+def cli(ffmpeg, source, output, duration, reset, peak, extra, extra_input):
     """FFMPEG noise detection."""
 
     def callback(state):
@@ -41,7 +42,7 @@ def cli(ffmpeg, source, output, duration, reset, peak, extra):
         sensor = SensorNoise(ffmpeg_bin=ffmpeg, callback=callback)
         sensor.set_options(time_duration=duration, time_reset=reset, peak=peak)
         await sensor.open_sensor(
-            input_source=source, output_dest=output, extra_cmd=extra
+            input_source=source, output_dest=output, extra_cmd=extra, extra_input_cmd=extra_input
         )
         try:
             while True:

--- a/test/tools_imageframe.py
+++ b/test/tools_imageframe.py
@@ -14,13 +14,14 @@ logging.basicConfig(level=logging.DEBUG)
 @click.option("--format_img", "-f", default=IMAGE_JPEG, help="Image output format")
 @click.option("--output", "-o", required=True, help="Output image file")
 @click.option("--extra", "-e", help="Extra ffmpeg command line arguments")
-def cli(ffmpeg, source, format_img, output, extra):
+@click.option("--extra-input", "-E", help="Extra ffmpeg command line arguments for input")
+def cli(ffmpeg, source, format_img, output, extra, extra_input):
     """FFMPEG capture frame as image."""
 
     async def capture_image():
         stream = ImageFrame(ffmpeg_bin=ffmpeg)
         return await stream.get_image(
-            input_source=source, output_format=format_img, extra_cmd=extra
+            input_source=source, output_format=format_img, extra_cmd=extra, extra_input_cmd=extra_input
         )
 
     image = asyncio.run(capture_image())


### PR DESCRIPTION
**Issue:**
https://community.home-assistant.io/t/camera-ffmpeg-able-to-add-extra-parameter-before-the-input-parameter/431177