### PR TITLE
Speed up starting camera streams

### DIFF
--- a/haffmpeg/core.py
+++ b/haffmpeg/core.py
@@ -132,6 +132,7 @@ class HAFFmpeg:
                 stdin=subprocess.PIPE,
                 stdout=stdout,
                 stderr=stderr,
+                close_fds=False,
             )
             self._proc = await self._loop.run_in_executor(None, proc_func)
         except Exception as err:  # pylint: disable=broad-except


### PR DESCRIPTION
closing fds can take a long time and its unlikely python is going to implement the close_range() system call [https://lwn.net/Articles/789023/] any time soon. Since we do not need to close the fds here as it does not cause any issues for ffmpeg we can spawn ffmpeg stream much faster in HA after https://github.com/home-assistant/core/pull/87958