### PR TITLE
Refactor to avoid using the executor

### DIFF
--- a/haffmpeg/sensor.py
+++ b/haffmpeg/sensor.py
@@ -3,11 +3,10 @@ import asyncio
 import logging
 import re
 from time import time
-from typing import Callable, Optional, Coroutine
-
-import async_timeout
+from typing import Callable, Coroutine, Optional
 
 from .core import FFMPEG_STDOUT, HAFFmpegWorker
+from .timeout import asyncio_timeout
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,7 +71,7 @@ class SensorNoise(HAFFmpegWorker):
         while True:
             try:
                 _LOGGER.debug("Reading State: %d, timeout: %s", state, timeout)
-                with async_timeout.timeout(timeout):
+                async with asyncio_timeout(timeout):
                     data = await self._queue.get()
                 timeout = None
                 if data is None:
@@ -189,7 +188,7 @@ class SensorMotion(HAFFmpegWorker):
         while True:
             try:
                 _LOGGER.debug("Reading State: %d, timeout: %s", state, timeout)
-                with async_timeout.timeout(timeout):
+                async with asyncio_timeout(timeout):
                     data = await self._queue.get()
                 if data is None:
                     self._loop.call_soon(self._callback, None)

--- a/haffmpeg/timeout.py
+++ b/haffmpeg/timeout.py
@@ -1,0 +1,8 @@
+"""Timeouts."""
+import sys
+
+if sys.version_info[:2] < (3, 11):
+    # pylint: disable-next=unused-import
+    from async_timeout import timeout as asyncio_timeout  # noqa: F401
+else:
+    from asyncio import timeout as asyncio_timeout  # noqa: F401


### PR DESCRIPTION
We currently have a problem in HA where users run out of executor threads and everything stalls.  This is part of an effort to reduce the amount of executor jobs. Convert to using `asyncio.create_subprocess_exec` since we avoid the executor step.

I tested this with homekit cameras and everything is a bit snappier. That's the only camera use case I have though so ~~it would be good to validate this with additional use cases before merging.~~ I tested this with an ffmpeg camera in HA as well.

```
2024-02-29 21:32:32.264 INFO (MainThread) [homeassistant.setup] Setting up ffmpeg
2024-02-29 21:32:32.276 INFO (MainThread) [asyncio] execute program 'ffmpeg': <_UnixSubprocessTransport pid=47484 running stdin=<_UnixWritePipeTransport fd=28 idle bufsize=0> stdout=<_UnixReadPipeTransport fd=29 polling>>
2024-02-29 21:32:32.314 INFO (MainThread) [asyncio] <_UnixReadPipeTransport fd=29 polling> was closed by peer
2024-02-29 21:32:32.314 INFO (MainThread) [asyncio] <_UnixSubprocessTransport pid=47484 running stdin=<_UnixWritePipeTransport closed fd=28 closed> stdout=<_UnixReadPipeTransport closing fd=29 idle>> exited with return code 0
2024-02-29 21:32:32.315 INFO (MainThread) [homeassistant.setup] Setup of domain ffmpeg took 0.1 seconds
```