### PR TITLE
Close process after tools functions return

### DIFF
--- a/haffmpeg/tools.py
+++ b/haffmpeg/tools.py
@@ -51,6 +51,9 @@ class ImageFrame(HAFFmpeg):
             self.kill()
             return None
 
+        finally:
+            await self.close(0)
+
 
 class FFVersion(HAFFmpeg):
     """Retrieve FFmpeg version information."""
@@ -82,5 +85,8 @@ class FFVersion(HAFFmpeg):
         except (asyncio.TimeoutError, ValueError):
             _LOGGER.warning("Timeout reading stdout.")
             self.kill()
+
+        finally:
+            await self.close(0)
 
         return None


### PR DESCRIPTION
Noticed some warnings in the Home Assistant core test logs. It seems that the process didn't get cleaned up properly sometimes. This PR adds explicit `self.close(0)` calls in the `finally` blocks.

<details>
<summary>HA test logs</summary>

```py
tests/components/cloud/test_google_config.py::test_google_config_get_agent_users
tests/components/bthome/test_config_flow.py::test_async_step_bluetooth_valid_device
  /home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/_pytest/unraisableexception.py:85: PytestUnraisableExceptionWarning: Exception ignored in: <function BaseSubprocessTransport.__del__ at 0x7fd093f6b2e0>
  
  Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/base_subprocess.py", line 126, in __del__
      self.close()
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/base_subprocess.py", line 104, in close
      proto.pipe.close()
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/unix_events.py", line 568, in close
      self._close(None)
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/unix_events.py", line 592, in _close
      self._loop.call_soon(self._call_connection_lost, exc)
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/base_events.py", line 795, in call_soon
      self._check_closed()
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/base_events.py", line 541, in _check_closed
      raise RuntimeError('Event loop is closed')
  RuntimeError: Event loop is closed
  
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))


tests/components/cloud/test_client.py::test_handler_google_actions_disabled[action.devices.SYNC-response_payload0]
tests/components/cloud/test_client.py::test_handler_google_actions_disabled[action.devices.QUERY-response_payload1]
tests/components/cloud/test_client.py::test_google_config_should_2fa
tests/components/cloud/test_client.py::test_system_msg
tests/components/cloud/test_alexa_config.py::test_alexa_handle_logout
  /home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/_pytest/unraisableexception.py:85: PytestUnraisableExceptionWarning: Exception ignored in: <function BaseSubprocessTransport.__del__ at 0x7fc85ff6f2e0>
  
  Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/base_subprocess.py", line 126, in __del__
      self.close()
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/base_subprocess.py", line 104, in close
      proto.pipe.close()
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/unix_events.py", line 767, in close
      self.write_eof()
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/unix_events.py", line 753, in write_eof
      self._loop.call_soon(self._call_connection_lost, None)
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/base_events.py", line 795, in call_soon
      self._check_closed()
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/base_events.py", line 541, in _check_closed
      raise RuntimeError('Event loop is closed')
  RuntimeError: Event loop is closed
  
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))


tests/components/stream/test_ll_hls.py::test_ll_hls_stream
  /home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/_pytest/unraisableexception.py:85: PytestUnraisableExceptionWarning: Exception ignored in: <function BaseSubprocessTransport.__del__ at 0x7fc2f5dd6c00>
  
  Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/base_subprocess.py", line 126, in __del__
      self.close()
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/base_subprocess.py", line 104, in close
      proto.pipe.close()
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/unix_events.py", line 568, in close
      self._close(None)
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/unix_events.py", line 592, in _close
      self._loop.call_soon(self._call_connection_lost, exc)
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/base_events.py", line 795, in call_soon
      self._check_closed()
    File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/asyncio/base_events.py", line 541, in _check_closed
      raise RuntimeError('Event loop is closed')
  RuntimeError: Event loop is closed
  
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
```
</details>