### PR TITLE
Close process in tools functions only if needed

### DIFF
--- a/haffmpeg/tools.py
+++ b/haffmpeg/tools.py
@@ -52,7 +52,8 @@ class ImageFrame(HAFFmpeg):
             return None
 
         finally:
-            await self.close(0)
+            if self.is_running:
+                await self.close(0)
 
 
 class FFVersion(HAFFmpeg):
@@ -87,6 +88,7 @@ class FFVersion(HAFFmpeg):
             self.kill()
 
         finally:
-            await self.close(0)
+            if self.is_running:
+                await self.close(0)
 
         return None


### PR DESCRIPTION
As of HA 2024.10.x and up to the current 2024.11 I'm getting a warning on startup:

```
WARNING (MainThread) [haffmpeg.core] FFmpeg isn't running!
```

It seems that [when checking the FFmpeg version](https://github.com/home-assistant/core/blob/0e324c074a3d307bfc839f0cf4d36092c4466d4c/homeassistant/components/ffmpeg/__init__.py#L161) the process exits earlier than #173 tries to close it, [generating that warning](https://github.com/home-assistant-libs/ha-ffmpeg/blob/410a24fbcfc2a7ebde2dd8aa085ac8e9e11998cd/haffmpeg/core.py#L148).
The check introduced by this PR may seem a bit redundant, but the only alternative I can think of is adding a flag to `close()` to allow for already-exited processes.